### PR TITLE
Suppress PowerShell errors

### DIFF
--- a/autoload/fakeclip.vim
+++ b/autoload/fakeclip.vim
@@ -167,8 +167,7 @@ endfunction
 
 
 function! s:read_clipboard_wsl()
-  let text = system('cd $(dirname $(which powershell.exe)) &&
-                    \ powershell.exe -noprofile -Command Get-Clipboard')
+  let text = system('powershell.exe -NoProfile -Command Get-Clipboard 2>/dev/null')
   let text = substitute(text, "\r", '', 'g')
   let text = substitute(text, '\n$', '', '')
   return text


### PR DESCRIPTION
On WSL2 (in the Windows Insider Preview), I’m experiencing PowerShell
currently emitting an error to stderr: “Attempting to perform the
InitializeDefaultDrives operation on the 'FileSystem' provider failed.”
I’m not certain why that happens, but I also don’t care, so drop stderr.

I’ve also herein removed the `cd …` dance which was introduced to work
around a WSL limitation described in #20 which has been fixed for some
time now (it’ll set the working directory to `\\wsl$\distro-name\path`,
and PowerShell’s fine with such a working directory, even if cmd.exe
wouldn’t be). I also believe that the `2>/dev/null` would suppress that
error anyway.